### PR TITLE
Update BCPGPDecryptor.java

### DIFF
--- a/src/main/java/com/test/pgp/bc/BCPGPDecryptor.java
+++ b/src/main/java/com/test/pgp/bc/BCPGPDecryptor.java
@@ -153,6 +153,9 @@ public class BCPGPDecryptor {
 			bytes = IOUtils.toByteArray(is);
 			
 			if (isSigned) {
+				if(ops == null){
+					throw new PGPException("Unsigned file, it's expected to be signed!");
+				}
 				ops.update(bytes);
 				PGPSignatureList p3 = (PGPSignatureList) pgpFact.nextObject();
 				if (!ops.verify(p3.get(0))) {


### PR DESCRIPTION
throw exception when a file is not signed when it is expected to be signed